### PR TITLE
ADS-2059: Shopify marketing consent and GDPR documentation

### DIFF
--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -1,10 +1,9 @@
-# Marketing permission and GDPR compatibility
 Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their ![GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
 
-![Consent during order confirmation]()
+![]()
 
 When the customer selects `Email me with news and offers` option and confims the order, the consent along with order information will be sent to Nosto through `/order/track` API in the following format,
 
@@ -32,7 +31,7 @@ When the customer selects `Email me with news and offers` option and confims the
 ## Consent - Customer update
 A merchant will be able to update customer's information or their marketing constent from store management (Admin) page. 
 
-![Update Marketing Consent]()
+![]()
 
 During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
 

--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -1,4 +1,4 @@
-Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their ![GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
+Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
@@ -46,5 +46,5 @@ During this process, shopify will share updated customer information through a r
 ```
 
 ### Note: 
-1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on ![Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)
-2. In order manually override marketing information for a customer email, follow the steps here ![Manually Override Consent](https://docs.nosto.com/techdocs/apis/rest/customers/toggling-email-opt-in-using-the-consent-api)
+1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on [Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)
+2. In order manually override marketing information for a customer email, follow the steps here [Manually Override Consent](https://docs.nosto.com/techdocs/apis/rest/customers/toggling-email-opt-in-using-the-consent-api)

--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -3,7 +3,7 @@ Marketing permission or newsletter constent from customers are recorded at Nosto
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
 
-![]()
+![Consent during order confirmation](https://user-images.githubusercontent.com/82023195/136540098-3719ca4f-77e6-47d1-8dfa-525010885064.png)
 
 When the customer selects `Email me with news and offers` option and confims the order, the consent along with order information will be sent to Nosto through `/order/track` API in the following format,
 
@@ -31,7 +31,7 @@ When the customer selects `Email me with news and offers` option and confims the
 ## Consent - Customer update
 A merchant will be able to update customer's information or their marketing constent from store management (Admin) page. 
 
-![]()
+![Update Marketing Consent](https://user-images.githubusercontent.com/82023195/136540161-057d6c72-fa25-4785-aa56-19a48a016200.png)
 
 During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
 

--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -33,7 +33,7 @@ A merchant will be able to update customer's information or their marketing cons
 
 ![Update Marketing Consent](https://user-images.githubusercontent.com/82023195/136540161-057d6c72-fa25-4785-aa56-19a48a016200.png)
 
-During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
+During this process, Nosto will receive updated customer information, in following format, through a pre-configured webhook,
 
 ```json
 {
@@ -44,6 +44,9 @@ During this process, shopify will share updated customer information through a r
     "accepts_marketing": true
 }
 ```
+
+## Consent - Customer Tagging
+A thrid approach for sending customer information to Nosto is using `Page tagging`. For more information, please refer [Customer Information Tagging](https://docs.nosto.com/techdocs/implementing-nosto/implement-on-your-website/manual-implementation/adding-the-customer-information)
 
 ### Note: 
 1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on [Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)

--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -1,4 +1,4 @@
-Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
+Marketing permission or newsletter consent from customers is recorded either during order confirmation or through customer webhooks. In case of order confirmation, the consent is received through the `marketingPermission` flag. These fields tell Nosto if the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -1,5 +1,5 @@
 # Marketing permission and GDPR compatibility
-Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
+Marketing permission or newsletter consent from customers is recorded either during order confirmation or through customer webhooks. In case of order confirmation, the consent is received through the `marketingPermission` flag. These fields tell Nosto if the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -34,7 +34,7 @@ A merchant will be able to update customer's information or their marketing cons
 
 ![Update Marketing Consent](https://user-images.githubusercontent.com/82023195/136540161-057d6c72-fa25-4785-aa56-19a48a016200.png)
 
-During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
+During this process, Nosto will receive updated customer information, in following format, through a pre-configured webhook,
 
 ```json
 {
@@ -45,6 +45,9 @@ During this process, shopify will share updated customer information through a r
     "accepts_marketing": true
 }
 ```
+
+## Consent - Customer Tagging
+A thrid approach for sending customer information to Nosto is using `Page tagging`. For more information, please refer [Customer Information Tagging](https://docs.nosto.com/techdocs/implementing-nosto/implement-on-your-website/manual-implementation/adding-the-customer-information)
 
 ### Note: 
 1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on [Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -1,5 +1,5 @@
 # Marketing permission and GDPR compatibility
-Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their ![GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
+Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
@@ -47,5 +47,5 @@ During this process, shopify will share updated customer information through a r
 ```
 
 ### Note: 
-1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on ![Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)
-2. In order manually override marketing information for a customer email, follow the steps here ![Manually Override Consent](https://docs.nosto.com/techdocs/apis/rest/customers/toggling-email-opt-in-using-the-consent-api)
+1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on [Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)
+2. In order manually override marketing information for a customer email, follow the steps here [Manually Override Consent](https://docs.nosto.com/techdocs/apis/rest/customers/toggling-email-opt-in-using-the-consent-api)

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -1,2 +1,47 @@
 # Marketing permission and GDPR compatibility
+Marketing permission or newsletter constent from customers are recorded at Nosto either during order confirmation (Conversion Tracking) or through customerUpdate webhook (Customer Feed). In case of order confirmation, the consent is received through the `marketingPermission` field in `OrderCustomer` bean and though `acceptsMarketing` field in `ShopifyCustomer` bean in case of webhook. These fields tells Nosto whether the customer has given their [GDPR](https://www.eugdpr.org/) compliant consent for receiving marketing emails.
 
+## Consent - Order confirmation
+When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
+
+[]()
+
+When the customer selects `Email me with news and offers` option and confims the order, the consent along with order information will be sent to Nosto through `/order/track` API in the following format,
+
+```json
+{
+    "info": {
+        "order_number":"4321633632470",
+        "type":"order",
+        "email":"manikandan.ravikumar@nosto.com",
+        "first_name":"Mani",
+        "last_name":"Nosto", 
+        "newsletter": "true"
+    },
+    "items": [{
+        "product_id":"7190446571734",
+        "sku_id":"41479723778262",
+        "name":"Cool Kicks",
+        "quantity":1,
+        "unit_price":123.12,
+        "price_currency_code":"EUR"
+    }]
+}
+```
+
+## Consent - Customer update
+A merchant will be able to update customer's information or their marketing constent from store management (Admin) page. During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
+
+```json
+{
+    "id": "12345",
+    "email":"manikandan.ravikumar@nosto.com",
+    "first_name":"Mani",
+    "last_name":"Nosto", 
+    "accepts_marketing": true
+}
+```
+
+### Note: 
+1. If your store has a custom process for gathering marketing permissions or the default logic explained above doesn't fit for your store, you can override Nosto's extension to amend the behaviour. Please read more detailed instructions in our guide on [Import customer data](https://help.nosto.com/en/articles/2884483-how-to-import-customer-data-to-nosto-via-api)
+2. In order manually override marketing information for a customer email, follow the steps here [Manually Override Consent](https://docs.nosto.com/techdocs/apis/rest/customers/toggling-email-opt-in-using-the-consent-api)

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -4,7 +4,7 @@ Marketing permission or newsletter constent from customers are recorded at Nosto
 ## Consent - Order confirmation
 When a customer is placing an order for any product, the checkout page will collect the customer's consent for receiving the marketing emails as shown below,
 
-![Consent during order confirmation]()
+![Consent during order confirmation](https://user-images.githubusercontent.com/82023195/136540098-3719ca4f-77e6-47d1-8dfa-525010885064.png)
 
 When the customer selects `Email me with news and offers` option and confims the order, the consent along with order information will be sent to Nosto through `/order/track` API in the following format,
 
@@ -32,7 +32,7 @@ When the customer selects `Email me with news and offers` option and confims the
 ## Consent - Customer update
 A merchant will be able to update customer's information or their marketing constent from store management (Admin) page. 
 
-![Update Marketing Consent]()
+![Update Marketing Consent](https://user-images.githubusercontent.com/82023195/136540161-057d6c72-fa25-4785-aa56-19a48a016200.png)
 
 During this process, shopify will share updated customer information through a registered webhook `https://webhooks.nosto.com/hub/shopify/customerFeed` in the following format,
 


### PR DESCRIPTION
Documentation explaining different ways for requesting Marketing or Email consent from customer 
a) Order confirmation
b) Customer Update
This documentation also covers the following concepts
a) Format of Json data during order confirmation and customer update
b) Explains how and where the email consent is retrieved or updated

## JIRA
[ADS-2059](https://nostosolutions.atlassian.net/browse/ADS-2059)

## Screenshots
<img width="640" alt="Screenshot 2021-10-08 at 10 58 11" src="https://user-images.githubusercontent.com/82023195/136540098-3719ca4f-77e6-47d1-8dfa-525010885064.png">
<img width="649" alt="Screenshot 2021-10-08 at 12 01 01" src="https://user-images.githubusercontent.com/82023195/136540161-057d6c72-fa25-4785-aa56-19a48a016200.png">


