### PR TITLE
ADS-2059: bigcommerce fix links

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,6 +13,7 @@
   * [Supplier Cost & Inventory Level](features/supplier-cost-and-inventory-level.md)
   * [Ratings & Reviews](features/ratings-and-reviews.md)
   * [Customer group pricing](features/customer-group-pricing.md)
+  * [Marketing consent & GDPR](features/marketing-consent-and-gdpr.md)
 * [FAQ](faq.md)
 * [Visit Nosto](https://nosto.com)
 * [Issues](https://github.com/nosto/nosto-bigcommerce/issues)


### PR DESCRIPTION
Fixing the missing summary link for the newly added `Marketing consent` documentation