### PR TITLE
ADS-2059: Rename GDPR link and fix summary navigation

### DIFF
--- a/Marketing-Permission-And-Gdpr-Compatibility.md
+++ b/Marketing-Permission-And-Gdpr-Compatibility.md
@@ -1,2 +1,1 @@
-# Marketing consent and GDPR
 Currently marketing permissions are not support for this merchant

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,7 @@
   * [Supplier Cost & Inventory Level](features/supplier-cost-and-inventory-level.md)
   * [Ratings & Reviews](features/ratings-and-reviews.md)
   * [Customer group pricing](features/customer-group-pricing.md)
-  * [Marketing consent & GDPR](features/marketing-consent-and-gdpr.md)
+  * [Marketing permission and GDPR compatibility](features/marketing-permission-and-gdpr-compatibility.md)
 * [FAQ](faq.md)
 * [Visit Nosto](https://nosto.com)
 * [Issues](https://github.com/nosto/nosto-bigcommerce/issues)

--- a/features/marketing-permission-and-gdpr-compatibility.md
+++ b/features/marketing-permission-and-gdpr-compatibility.md
@@ -1,2 +1,2 @@
-# Marketing consent and GDPR
+# Marketing permission and GDPR compatibility
 Currently marketing permissions are not support for this merchant


### PR DESCRIPTION
This PR renames the BigCommerce GDPR links and also renames the navigation texts to match that of Shopify documentation setup