### PR TITLE
Add article to exclude pulling nosto packages from Magento repo

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -27,6 +27,19 @@ You might need to change file permissions or ownership of the generated files af
 
 After running the commands above you can login to the store admin. You will find Nosto -link under Marketing section.
 
+#### Magento's repo does not contain the latest release
+In case you are pulling the dependencies from Magento's repository `repo.magento.com` and you encounter an error where the latest release is not present, 
+you can [exclude](https://getcomposer.org/doc/articles/repository-priorities.md#filtering-packages) Nosto packages and instead pull them from the default repository `https://repo.packagist.org/`. 
+```json
+"repositories": [
+    {
+        "type": "composer",
+        "url": "https://repo.magento.com/",
+        "exclude": ["nosto/*"]
+    }
+]
+```
+
 ## Indexer mode
 
 We strongly recommend that you set the mode for Nosto indexer\(s\) to be "Update by schedule". This is important especially with large product catalogs and / or when using multiple store views. Read more about indexer performance and optimization [here](features/indexer/)

--- a/installing.md
+++ b/installing.md
@@ -28,8 +28,10 @@ You might need to change file permissions or ownership of the generated files af
 After running the commands above you can login to the store admin. You will find Nosto -link under Marketing section.
 
 #### Magento's repo does not contain the latest release
+
 In case you are pulling the dependencies from Magento's repository `repo.magento.com` and you encounter an error where the latest release is not present, 
 you can [exclude](https://getcomposer.org/doc/articles/repository-priorities.md#filtering-packages) Nosto packages and instead pull them from the default repository `https://repo.packagist.org/`. 
+
 ```json
 "repositories": [
     {


### PR DESCRIPTION
This article cover instructions on how to handle the following error:

````
- Root composer.json requires nosto/module-nostotagging 5.2.10, it is satisfiable by nosto/module-nostotagging[5.2.10] from composer repo (https://repo.packagist.org) but nosto/module-nostotagging[1.1.1, 1.2.0, 2.1.0, ..., 2.11.0, 3.0.2, 3.7.0, 3.8.5, 5.0.7, 5.2.3] from composer repo (https://repo.magento.com) has higher repository priority. The packages with higher priority do not match your constraint and are therefore not installable.
````