### PR TITLE
ADS-3223: Online Store 2.0 support

### DIFF
--- a/Online-Store-2.md
+++ b/Online-Store-2.md
@@ -1,0 +1,4 @@
+# Online Store 2.0
+
+## Summary
+We support `Online Store 2.0` themes

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -20,6 +20,7 @@
   * [Multi Currency Support](features/multi-currency-support.md)
   * [Shopify Flow](features/shopify-flow.md)
   * [Marketing permission and GDPR compatibility](features/marketing-permission-and-gdpr-compatibility.md)
+  * [Online Store 2.0](features/online-store-2.md)
 * [Integrations](integrations/README.md)
   * [Using Yotpo](integrations/integration-yotpo.md)
   * [Using Stamped.IO](integrations/integration-stamped.md)

--- a/features/online-store-2.md
+++ b/features/online-store-2.md
@@ -1,0 +1,4 @@
+# Online Store 2.0
+
+## Summary
+We support `Online Store 2.0` themes

--- a/guides/adding-removing-or-moving-recommendations.md
+++ b/guides/adding-removing-or-moving-recommendations.md
@@ -10,23 +10,22 @@ Use Shopify's theme editor to find the associated Liquid file to edit it. In the
 
 Nosto places the following recommendation placeholders on the site.
 
-| Element Name | Theme File |
-| :--- | :--- |
-| `<div class="nosto_element" id="frontpage-nosto-1" />` | templates/index.liquid |
-| `<div class="nosto_element" id="frontpage-nosto-2" />` | templates/index.liquid |
-| `<div class="nosto_element" id="frontpage-nosto-3" />` | templates/index.liquid |
-| `<div class="nosto_element" id="frontpage-nosto-4" />` | templates/index.liquid |
-| `<div class="nosto_element" id="productpage-nosto-1" />` | templates/product.liquid |
-| `<div class="nosto_element" id="productpage-nosto-2" />` | templates/product.liquid |
-| `<div class="nosto_element" id="productpage-nosto-3" />` | templates/product.liquid |
-| `<div class="nosto_element" id="categorypage-nosto-1" />` | templates/collection.liquid |
-| `<div class="nosto_element" id="categorypage-nosto-2" />` | templates/collection.liquid |
-| `<div class="nosto_element" id="searchpage-nosto-1" />` | templates/search.liquid |
-| `<div class="nosto_element" id="searchpage-nosto-2" />` | templates/search.liquid |
-| `<div class="nosto_element" id="notfound-nosto-1" />` | templates/404.liquid |
-| `<div class="nosto_element" id="notfound-nosto-2" />` | templates/404.liquid |
-| `<div class="nosto_element" id="notfound-nosto-3" />` | templates/404.liquid |
-| `<div class="nosto_element" id="cartpage-nosto-1" />` | templates/cart.liquid |
-| `<div class="nosto_element" id="cartpage-nosto-2" />` | templates/cart.liquid |
-| `<div class="nosto_element" id="cartpage-nosto-3" />` | templates/cart.liquid |
-
+| Element Name | Theme File (OS1) | Theme File (OS2) - Updated | Theme File (OS2) - Added |
+| :--: | :--: | :--: | :--: |
+| `<div class="nosto_element" id="frontpage-nosto-1" />` | templates/index.liquid | templates/index.json | section/nosto-index.liquid |
+| `<div class="nosto_element" id="frontpage-nosto-2" />` | templates/index.liquid | templates/index.json | section/nosto-index.liquid |
+| `<div class="nosto_element" id="frontpage-nosto-3" />` | templates/index.liquid | templates/index.json | section/nosto-index.liquid |
+| `<div class="nosto_element" id="frontpage-nosto-4" />` | templates/index.liquid | templates/index.json | section/nosto-index.liquid |
+| `<div class="nosto_element" id="productpage-nosto-1" />` | templates/product.liquid | templates/product.json | section/nosto-product.liquid |
+| `<div class="nosto_element" id="productpage-nosto-2" />` | templates/product.liquid | templates/product.json | section/nosto-product.liquid |
+| `<div class="nosto_element" id="productpage-nosto-3" />` | templates/product.liquid | templates/product.json | section/nosto-product.liquid |
+| `<div class="nosto_element" id="categorypage-nosto-1" />` | templates/collection.liquid | templates/collection.json | section/nosto-collection-prepend.liquid |
+| `<div class="nosto_element" id="categorypage-nosto-2" />` | templates/collection.liquid | templates/collection.json | section/nosto-collection-append.liquid |
+| `<div class="nosto_element" id="searchpage-nosto-1" />` | templates/search.liquid | templates/search.json | section/nosto-search-prepend.liquid |
+| `<div class="nosto_element" id="searchpage-nosto-2" />` | templates/search.liquid | templates/search.json | section/nosto-search-append.liquid |
+| `<div class="nosto_element" id="notfound-nosto-1" />` | templates/404.liquid | templates/404.json | section/nosto-404.liquid |
+| `<div class="nosto_element" id="notfound-nosto-2" />` | templates/404.liquid | templates/404.json | section/nosto-404.liquid |
+| `<div class="nosto_element" id="notfound-nosto-3" />` | templates/404.liquid | templates/404.json | section/nosto-404.liquid |
+| `<div class="nosto_element" id="cartpage-nosto-1" />` | templates/cart.liquid | templates/cart.json | section/nosto-cart.liquid |
+| `<div class="nosto_element" id="cartpage-nosto-2" />` | templates/cart.liquid | templates/cart.json | section/nosto-cart.liquid |
+| `<div class="nosto_element" id="cartpage-nosto-3" />` | templates/cart.liquid | templates/cart.json | section/nosto-cart.liquid |


### PR DESCRIPTION
A simple documentation that notifies the support for the new `Online Store 2.0` Shopify themes.

## Original PR
[23493](https://github.com/Nosto/playcart/pull/23493)

## JIRA
[ADS-3223](https://nostosolutions.atlassian.net/browse/ADS-3223)