### PR TITLE
added ?op=add to example

### DIFF
--- a/apis/rest/customers/blacklisting-customers-using-the-blacklist-api.md
+++ b/apis/rest/customers/blacklisting-customers-using-the-blacklist-api.md
@@ -13,7 +13,7 @@ This endpoint requires an Email token.
 You can specify multiple email addresses separated by a newline.
 
 ```text
-curl -v -X POST https://api.nosto.com/v1/email/blacklist \
+curl -v -X POST https://api.nosto.com/v1/email/blacklist?op=add \
 --user :WI0j2oN7TgG42tlblX3yzOQ5xvCYc2oYj9eWg79lghVq8R0nKQXlVE9wvihBUFOw -d '
 john.doe@nosto.com
 jane.doe@nosto.com'


### PR DESCRIPTION
Without `?op=add` request fails with error:
```
{
    "type": "bad_request",
    "message": "Operation argument was missing. Supported operation types are ['add', 'remove] "
}
```