### PR TITLE
ADS-3280: Update BigCommerce customer group pricing documentation

### DIFF
--- a/Customer-Group-Pricing.md
+++ b/Customer-Group-Pricing.md
@@ -39,7 +39,7 @@ The json format of a single product variation will look like,
 
 ```json
 {
-  variation_id: 'VAR_1',
+  variation_id: '1_USD',
   price: 360,
   list_price: 260, //This can be a discount rule with PRICE method with a value of 100
   availability: 'InStock',
@@ -54,7 +54,7 @@ An example of default variation data,
 
 ```json
 {
-  variation_id: 'DEF_1',
+  variation_id: '1_EUR',
   price: 360,
   list_price: 360, //There is no discount rule here. Product price is used as it is
   availability: 'InStock',
@@ -70,7 +70,7 @@ In order to make use of the `Product Variation` approach, it needs to be enabled
 
 Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
-![](https://user-images.githubusercontent.com/82023195/154737808-5a86254f-88bd-4ddb-9fb7-0321eebbc163.png)
+![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 
 ### Product Reindexing
 After completing the set up under `Currency Settings`, re-index the products by following the below steps:

--- a/Customer-Group-Pricing.md
+++ b/Customer-Group-Pricing.md
@@ -66,9 +66,13 @@ An example of default variation data,
 ## Activating customer group pricing in Nosto
 
 ### Currency Settings
-In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the steps outlined below,
+In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the below steps:
 
-Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
+1. Navigate to `Settings > Currency Settings` in Nosto admin, 
+2. Disable `Exchange rates` toggle (if it's enabled) 
+3. Configure `Variation ID`  (this is considered the default variation id). 
+
+If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
 ![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 

--- a/Customer-Group-Pricing.md
+++ b/Customer-Group-Pricing.md
@@ -3,20 +3,20 @@ Nosto recently implemented support for **Customer Group Pricing** feature, descr
 > **Note:** In this initial release, nosto only supports discount rules for merchant default currency (say, EUR). When a product has no  discount rules matching the merchant default currency, then no recommendations will be served.
 
 ## Customer groups
-A customer group is a set of rules for configuring product promotions or discounts using different pricing strategies as below,
+A customer group is a set of rules for configuring product promotions or discounts using different pricing strategies as below:
 * Product Rule - This rule will define discount rules for each product
 * Category Rule - This rule will define rules for product categories. When defined, all products belonging to this category will received the discount offered. This can be further refined to include **direct** sub-categories of the selected product
 * Store Rule - There can be only one store discount rule for a customer group. This rule will define discount rules for all the store products
-* Price Lists - Price Lists are special form of defining discount rules. A store can have many price lists. This is similar to `Product Rule` discount rule except that price list offers flexibility of defining rules for each and every product at once. This can be used when there's a requirement for defining rules for huge number of products. 
+* Price Lists - Price Lists are special form of defining discount rules. A store can have many price lists. This is similar to "Product Rule" discount rule except that price list offers flexibility of defining rules for each and every product at once. This can be used when there's a requirement for defining rules for huge number of products. 
 
-**Note:** A customer group can only have a `Price List` rule OR Product and/or Category and/or store rule. These customer groups will then be associated with the customers.
+**Note:** A customer group can only have a Price List Rule OR Product and/or Category and/or store rule. Customer groups are associated with the customers.
 
-Following are the pricing strategies that can be associated with pricing rules defined above
+Following are the pricing strategies that can be associated with pricing rules defined above:
 * Fixed pricing - Value defined will be the exact selling price of the product
 * Percent pricing - Value defined will be the percentage value of the product list price. For e.g. if this value is 1, that means the product is offered at a 1% discount from the list price
 * Price pricing - Value defined will be directly discounted from the product list price. For e.g. if this value is 100, that means the product price will be 100 less than the list price
 
-**Note:** A Price List rule can only be defined using `Percent` pricing strategy.
+**Note:** A Price List rule can only be defined using "Percent" pricing strategy.
 
 ### Rules precedence
 Rules are applied in following order
@@ -27,13 +27,13 @@ Rules are applied in following order
 
 ## Nosto's implementation
 Nosto maps each customer group id as a product variation ID
-for e.g. if the customer_group_id is `1`, then variation ID will be `1`.
+for e.g. if the customer_group_id is "1", then variation ID will be "1".
 In addition to Variation ID, a product variation has the following component,
 * price - The selling price of the product including the discount as per the discount rule.
 * list price - The actual price of the product excluding the discount.
-* availability - Current status of product availability. For e.g. `In Stock` or `Out of Stock`.
-* currency code - currency code of the product pricing rule. A rule can be defined in one currency but still be applied on different currency code. Consider, the product currency is `eur`, the customer is ordering using `usd` and the customer belongs to a customer group, 
-In the situation, promotion will be converted to `usd` but  customer will still be paying in `eur` during checkout.
+* availability - Current status of product availability. For e.g. In Stock or Out of Stock.
+* currency code - currency code of the product pricing rule. A rule can be defined in one currency but still be applied on different currency code. Consider, the product currency is "eur", the customer is ordering using "usd" and the customer belongs to a customer group, 
+In the situation, promotion will be converted to "usd" but  customer will still be paying in "eur" during checkout.
 
 The json format of a single product variation will look like,
 
@@ -66,22 +66,22 @@ An example of default variation data,
 ## Activating customer group pricing in Nosto
 
 ### Currency Settings
-In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the below steps:
+Please follow the below steps to enable product variation from Nosto Admin:
 
-1. Navigate to `Settings > Currency Settings` in Nosto admin, 
-2. Disable `Exchange rates` toggle (if it's enabled) 
-3. Configure `Variation ID`  (this is considered the default variation id). 
+1. Navigate to Settings > Currency Settings in Nosto admin, 
+2. Disable "Exchange rates" toggle (if it's enabled) 
+3. Configure "Variation ID" text field  (this is considered the default variation id). 
 
 If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
 ![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 
 ### Product Reindexing
-After completing the set up under `Currency Settings`, re-index the products by following the below steps:
+After completing the steps in previous section, re-index the products by following the below steps:
 1. Navigate to Catalog Explorer > Products page 
 2. Click "Update Catalog"
 
 ![](https://user-images.githubusercontent.com/82023195/154738159-823129bd-2e07-4262-8817-a1300dfa4963.png)
    
-Note: Re-indexing may take some time to complete, depending on the product count. 
+Note: Re-indexing may take some time to complete, depending on the product count.
 

--- a/Customer-Group-Pricing.md
+++ b/Customer-Group-Pricing.md
@@ -16,7 +16,7 @@ Following are the pricing strategies that can be associated with pricing rules d
 * Percent pricing - Value defined will be the percentage value of the product list price. For e.g. if this value is 1, that means the product is offered at a 1% discount from the list price
 * Price pricing - Value defined will be directly discounted from the product list price. For e.g. if this value is 100, that means the product price will be 100 less than the list price
 
-**Note:** A Price List rule can only be defined using `Percent` pricing strategry.
+**Note:** A Price List rule can only be defined using `Percent` pricing strategy.
 
 ### Rules precedence
 Rules are applied in following order
@@ -26,9 +26,8 @@ Rules are applied in following order
 4. Store Rule, if available
 
 ## Nosto's implementation
-Nosto maps each customer group and it's currency as a product price variation with Variation ID takling the form
-> customer_group_id + '_' + currency_code
-for e.g. if the customer_group_id is `1` and currency code is `eur`, then variation ID will be `1_eur`.
+Nosto maps each customer group id as a product variation ID
+for e.g. if the customer_group_id is `1`, then variation ID will be `1`.
 In addition to Variation ID, a product variation has the following component,
 * price - The selling price of the product including the discount as per the discount rule.
 * list price - The actual price of the product excluding the discount.
@@ -40,7 +39,7 @@ The json format of a single product variation will look like,
 
 ```json
 {
-  variation_id: '1_eur',
+  variation_id: 'VAR_1',
   price: 360,
   list_price: 260, //This can be a discount rule with PRICE method with a value of 100
   availability: 'InStock',
@@ -49,22 +48,36 @@ The json format of a single product variation will look like,
 }
 ```
 
+In addition to the variations fetched, Nosto adds the default variation ID (as configured in "Nosto Admin"), where both price and list_price will have the same value. This is because Nosto requires all products to be associated with the default variation ID.
+
+An example of default variation data,
+
+```json
+{
+  variation_id: 'DEF_1',
+  price: 360,
+  list_price: 360, //There is no discount rule here. Product price is used as it is
+  availability: 'InStock',
+  price_text: '360',
+  price_currency_code: 'eur' //Merchant currency code
+}
+```
+
 ## Activating customer group pricing in Nosto
 
 ### Currency Settings
 In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the steps outlined below,
 
-Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and enter a default `Variation ID`. 
-If we consider our example in the previous section and configure the currency settings, it will look as shown below,
+Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
-![](https://user-images.githubusercontent.com/82023195/134679655-c9d68242-e595-4b2b-b217-6916360ef532.png)
+![](https://user-images.githubusercontent.com/82023195/154737808-5a86254f-88bd-4ddb-9fb7-0321eebbc163.png)
 
 ### Product Reindexing
-After completing the set up under `Currency Settings`, navigate to `Product Indexer` page using the following link
-> https://my.nosto.com/admin/{MERCHANT_NAME}/reindexer
-**Note:** Be sure to replace the {MERCHANT_NAME} above with the actual merchant name
+After completing the set up under `Currency Settings`, re-index the products by following the below steps:
+1. Navigate to Catalog Explorer > Products page 
+2. Click "Update Catalog"
 
-![](https://user-images.githubusercontent.com/82023195/134689417-f03cce32-2759-465c-b285-c943ee9b5575.png)
-
-In the above screen, do a `Request` and then `Flush All Products` which completes the reindexing process.
+![](https://user-images.githubusercontent.com/82023195/154738159-823129bd-2e07-4262-8817-a1300dfa4963.png)
+   
+Note: Re-indexing may take some time to complete, depending on the product count. 
 

--- a/features/customer-group-pricing.md
+++ b/features/customer-group-pricing.md
@@ -4,20 +4,20 @@ Nosto recently implemented support for **Customer Group Pricing** feature, descr
 > **Note:** In this initial release, nosto only supports discount rules for merchant default currency (say, EUR). When a product has no  discount rules matching the merchant default currency, then no recommendations will be served.
 
 ## Customer groups
-A customer group is a set of rules for configuring product promotions or discounts using different pricing strategies as below,
+A customer group is a set of rules for configuring product promotions or discounts using different pricing strategies as below:
 * Product Rule - This rule will define discount rules for each product
 * Category Rule - This rule will define rules for product categories. When defined, all products belonging to this category will received the discount offered. This can be further refined to include **direct** sub-categories of the selected product
 * Store Rule - There can be only one store discount rule for a customer group. This rule will define discount rules for all the store products
-* Price Lists - Price Lists are special form of defining discount rules. A store can have many price lists. This is similar to `Product Rule` discount rule except that price list offers flexibility of defining rules for each and every product at once. This can be used when there's a requirement for defining rules for huge number of products. 
+* Price Lists - Price Lists are special form of defining discount rules. A store can have many price lists. This is similar to "Product Rule" discount rule except that price list offers flexibility of defining rules for each and every product at once. This can be used when there's a requirement for defining rules for huge number of products. 
 
-**Note:** A customer group can only have a `Price List` rule OR Product and/or Category and/or store rule. These customer groups will then be associated with the customers.
+**Note:** A customer group can only have a Price List Rule OR Product and/or Category and/or store rule. Customer groups are associated with the customers.
 
-Following are the pricing strategies that can be associated with pricing rules defined above
+Following are the pricing strategies that can be associated with pricing rules defined above:
 * Fixed pricing - Value defined will be the exact selling price of the product
 * Percent pricing - Value defined will be the percentage value of the product list price. For e.g. if this value is 1, that means the product is offered at a 1% discount from the list price
 * Price pricing - Value defined will be directly discounted from the product list price. For e.g. if this value is 100, that means the product price will be 100 less than the list price
 
-**Note:** A Price List rule can only be defined using `Percent` pricing strategy.
+**Note:** A Price List rule can only be defined using "Percent" pricing strategy.
 
 ### Rules precedence
 Rules are applied in following order
@@ -28,13 +28,13 @@ Rules are applied in following order
 
 ## Nosto's implementation
 Nosto maps each customer group id as a product variation ID
-for e.g. if the customer_group_id is `1`, then variation ID will be `1`.
+for e.g. if the customer_group_id is "1", then variation ID will be "1".
 In addition to Variation ID, a product variation has the following component,
 * price - The selling price of the product including the discount as per the discount rule.
 * list price - The actual price of the product excluding the discount.
-* availability - Current status of product availability. For e.g. `In Stock` or `Out of Stock`.
-* currency code - currency code of the product pricing rule. A rule can be defined in one currency but still be applied on different currency code. Consider, the product currency is `eur`, the customer is ordering using `usd` and the customer belongs to a customer group, 
-In the situation, promotion will be converted to `usd` but  customer will still be paying in `eur` during checkout.
+* availability - Current status of product availability. For e.g. In Stock or Out of Stock.
+* currency code - currency code of the product pricing rule. A rule can be defined in one currency but still be applied on different currency code. Consider, the product currency is "eur", the customer is ordering using "usd" and the customer belongs to a customer group, 
+In the situation, promotion will be converted to "usd" but  customer will still be paying in "eur" during checkout.
 
 The json format of a single product variation will look like,
 
@@ -67,18 +67,18 @@ An example of default variation data,
 ## Activating customer group pricing in Nosto
 
 ### Currency Settings
-In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the below steps:
+Please follow the below steps to enable product variation from Nosto Admin:
 
-1. Navigate to `Settings > Currency Settings` in Nosto admin, 
-2. Disable `Exchange rates` toggle (if it's enabled) 
-3. Configure `Variation ID`  (this is considered the default variation id). 
+1. Navigate to Settings > Currency Settings in Nosto admin, 
+2. Disable "Exchange rates" toggle (if it's enabled) 
+3. Configure "Variation ID" text field  (this is considered the default variation id). 
 
 If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
 ![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 
 ### Product Reindexing
-After completing the set up under `Currency Settings`, re-index the products by following the below steps:
+After completing the steps in previous section, re-index the products by following the below steps:
 1. Navigate to Catalog Explorer > Products page 
 2. Click "Update Catalog"
 

--- a/features/customer-group-pricing.md
+++ b/features/customer-group-pricing.md
@@ -67,9 +67,13 @@ An example of default variation data,
 ## Activating customer group pricing in Nosto
 
 ### Currency Settings
-In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the steps outlined below,
+In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the below steps:
 
-Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
+1. Navigate to `Settings > Currency Settings` in Nosto admin, 
+2. Disable `Exchange rates` toggle (if it's enabled) 
+3. Configure `Variation ID`  (this is considered the default variation id). 
+
+If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
 ![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 

--- a/features/customer-group-pricing.md
+++ b/features/customer-group-pricing.md
@@ -17,7 +17,7 @@ Following are the pricing strategies that can be associated with pricing rules d
 * Percent pricing - Value defined will be the percentage value of the product list price. For e.g. if this value is 1, that means the product is offered at a 1% discount from the list price
 * Price pricing - Value defined will be directly discounted from the product list price. For e.g. if this value is 100, that means the product price will be 100 less than the list price
 
-**Note:** A Price List rule can only be defined using `Percent` pricing strategry.
+**Note:** A Price List rule can only be defined using `Percent` pricing strategy.
 
 ### Rules precedence
 Rules are applied in following order
@@ -40,7 +40,7 @@ The json format of a single product variation will look like,
 
 ```json
 {
-  variation_id: '1',
+  variation_id: 'VAR_1',
   price: 360,
   list_price: 260, //This can be a discount rule with PRICE method with a value of 100
   availability: 'InStock',
@@ -49,12 +49,13 @@ The json format of a single product variation will look like,
 }
 ```
 
-In addition to the variations fetched, Nosto adds a default variation ID `0` where both price and list_price will have the same value.
-This is because Nosto requires all products to be associated with the default variation ID.
+In addition to the variations fetched, Nosto adds the default variation ID (as configured in "Nosto Admin"), where both price and list_price will have the same value. This is because Nosto requires all products to be associated with the default variation ID.
+
+An example of default variation data,
 
 ```json
 {
-  variation_id: '1',
+  variation_id: 'DEF_1',
   price: 360,
   list_price: 360, //There is no discount rule here. Product price is used as it is
   availability: 'InStock',
@@ -68,19 +69,15 @@ This is because Nosto requires all products to be associated with the default va
 ### Currency Settings
 In order to make use of the `Product Variation` approach, it needs to be enabled from Nosto admin. Please follow the steps outlined below,
 
-Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and enter `0` for `Variation ID`. 
-If we consider our example in the previous section and configure the currency settings, it will look as shown below,
+Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
-![](https://user-images.githubusercontent.com/82023195/135241593-7effaad4-f8d9-4c12-80d8-4b9de2aeadba.png)
+![](https://user-images.githubusercontent.com/82023195/154737808-5a86254f-88bd-4ddb-9fb7-0321eebbc163.png)
 
 ### Product Reindexing
-After completing the set up under `Currency Settings`, navigate to `Product Indexer` page using the following link
-> https://my.nosto.com/admin/{MERCHANT_NAME}/reindexer
-**Note:** Be sure to replace the {MERCHANT_NAME} above with the actual merchant name
+After completing the set up under `Currency Settings`, re-index the products by following the below steps:
+1. Navigate to Catalog Explorer > Products page 
+2. Click "Update Catalog"
 
-![](https://user-images.githubusercontent.com/82023195/134689417-f03cce32-2759-465c-b285-c943ee9b5575.png)
-
-In the above screen, do a `Request` and then `Flush All Products` which completes the reindexing process.
-
-Optionally, a `Settings > Platforms > Sync Products` can also be performed manually
-
+![](https://user-images.githubusercontent.com/82023195/154738159-823129bd-2e07-4262-8817-a1300dfa4963.png)
+   
+Note: Re-indexing may take some time to complete, depending on the product count. 

--- a/features/customer-group-pricing.md
+++ b/features/customer-group-pricing.md
@@ -40,7 +40,7 @@ The json format of a single product variation will look like,
 
 ```json
 {
-  variation_id: 'VAR_1',
+  variation_id: '1_USD',
   price: 360,
   list_price: 260, //This can be a discount rule with PRICE method with a value of 100
   availability: 'InStock',
@@ -55,7 +55,7 @@ An example of default variation data,
 
 ```json
 {
-  variation_id: 'DEF_1',
+  variation_id: '1_EUR',
   price: 360,
   list_price: 360, //There is no discount rule here. Product price is used as it is
   availability: 'InStock',
@@ -71,7 +71,7 @@ In order to make use of the `Product Variation` approach, it needs to be enabled
 
 Navigate to `Settings > Currency Settings` in Nosto admin, disable `Exchange rates` toggle and configure `Variation ID` which is considered the default variation id. If we consider our example in the previous section and configure the currency settings, it will look as shown below,
 
-![](https://user-images.githubusercontent.com/82023195/154737808-5a86254f-88bd-4ddb-9fb7-0321eebbc163.png)
+![](https://user-images.githubusercontent.com/82023195/154739514-8e5f078a-cf6d-45b1-b51b-dccc7a690396.png)
 
 ### Product Reindexing
 After completing the set up under `Currency Settings`, re-index the products by following the below steps:


### PR DESCRIPTION
This PR addresses the following discrepancies with "BigCommerce customer group pricing" documentation. 

1. The logic for handling default variation in BigCommerce CGP logic was improved recently to use the configured default variation id instead of a default 0. 
2. The documentation was pointing to the older "Re-Indexer" screen which is not accessible by the merchant. 