### PR TITLE
ADS-3608: Add scope in Dynamic bundle discounts documentation

### DIFF
--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -7,12 +7,6 @@
     - [Shopify Line Item script](#shopify-line-item-script)
   - [Important Note](#important-note)
   - [Scope](#scope)
-    - [Bundle Discount Example](#bundle-discount-example)
-    - [Supported Scenarios](#supported-scenarios)
-      - [When all the products of a bundle offering are added to the cart](#when-all-the-products-of-a-bundle-offering-are-added-to-the-cart)
-      - [When all the products of a bundle offering are added to the cart alogn with PDP product](#when-all-the-products-of-a-bundle-offering-are-added-to-the-cart-alogn-with-pdp-product)
-    - [Scenarios not supported](#scenarios-not-supported)
-      - [When a partial bundle is added to cart](#when-a-partial-bundle-is-added-to-cart)
   - [Will not work If](#will-not-work-if)
   - [Known Issues](#known-issues)
   - [Authentication Script](#authentication-script)
@@ -139,36 +133,8 @@ Nosto Dynamic Bundle configuration involves two important keys, hash and secret 
 Secret key, on the other hand, can be retrieved from "Dynamic Bundle Key" field in Nosto Admin Settings > Platform page. This value replaces GET\_FROM\_NOSTO placeholder in the Shopify line item script.
 
 ## Scope
-Scope of this initial release is to support discounts on bundled product offerings. 
-
-### Bundle Discount Example
-Let's say, in PDP for Product#1, we display a bundle of products Product#2, Product#3 & Product#4 along with the only action button "Add to cart". 
-
-### Supported Scenarios
-The logic works only under the following scenarios:
-_Note: This section is subjected to change in future_
-
-#### When all the products of a bundle offering are added to the cart
-     
-Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above
-Upon clicking "Add to cart" button, Nosto script adds all the products of bundle Product#2, Product#3 & Product#4 to cart and applies the pre-configured discount
-
-#### When all the products of a bundle offering are added to the cart alogn with PDP product
-
-Recommendation templates for bundle offerings can be configured to include currently displayed product for discount when a bundle is added to car, using the `discountCurrentProduct` discussed under section [Nosto Dynamic Bundle template](#nosto-dynamic-bundle-template) above.
-
-Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above and assuming the `discountCurrentProduct` variable in the recommendation template is set to `true`,
-Upon clicking "Add to cart" button, Nosto script adds all the products of bundle Product#2, Product#3, Product#4 and **Product#1** (currently displayed product), to cart and applies the pre-configured discount
-
-### Scenarios not supported
-
-#### When a partial bundle is added to cart
-
-When we offer the option of selecting only specific products from a bundle, say with a checkbox or option button, in the recommendation template, specific products can be selected or deselected from a bundle and then added to cart. In this situation, the logic will not apply discount on any product.   
-Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above and assuming each product in the bundle has an associated checkbox, for selecting or deselecting a product
-Product#3 in the bundle is deselected using the checkbox and "Add to cart" button is clicked. In this scenario, only Product#2 and Product#4 gets added to cart with no discounts. 
-
-**In order to overcome this issue, the template shouldn't include any option for selecting or deselecting products**
+In scope - Apply discounts when all the products in a bundle are added to cart. 
+Not in scope - Selecting only specific products from a bundle, for discounts.
 
 ## Will not work If
 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -688,7 +688,7 @@ In such a case, make the following changes to the template liquid file that disp
 1. Nosto cannot provide support for the line item script if any customisations are made to it.
 2. Incorrect value used for SECRET_KEY. 
 3. Issue with Bundle script configuration.
-4. Not all the products from a bundle is added to cart.
+4. Not all the products from a bundle are added to cart.
 
 ### Solution
 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -647,7 +647,7 @@ Output.cart = Input.cart
 
 ## Troubleshooting
 
-### Issue #1: When additional content displayed in cart page
+### Issue #1: Additional content displayed on cart page
 
 ![Properties Exposed](https://user-images.githubusercontent.com/82023195/168611801-666c24bc-c7f9-4edd-bdf5-2be32798391c.png)
 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -685,7 +685,7 @@ In such a case, make the following changes to the template liquid file that disp
 
 ### Cause
 
-1. Nosto provided scripts are not used as-is. 
+1. Nosto provided scripts are not used as-is. Nosto can't provide support in this case.
 2. Incorrect value used for SECRET_KEY. 
 3. Issue with Bundle script configuration.
 4. Not all the products from a bundle is added to cart.

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -685,7 +685,7 @@ In such a case, make the following changes to the template liquid file that disp
 
 ### Cause
 
-1. Nosto provided scripts are not used as-is. Nosto can't provide support in this case.
+1. Nosto cannot provide support for the line item script if any customisations are made to it.
 2. Incorrect value used for SECRET_KEY. 
 3. Issue with Bundle script configuration.
 4. Not all the products from a bundle is added to cart.

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -5,6 +5,7 @@
   - [Setup](#setup)
     - [Nosto Dynamic Bundle template](#nosto-dynamic-bundle-template)
     - [Shopify Line Item script](#shopify-line-item-script)
+    - [Debugging Line Item Script](#debugging-line-item-script)
   - [Important Note](#important-note)
   - [Nosto Bundle Script](#nosto-bundle-script)
   - [Troubleshooting](#troubleshooting)
@@ -119,9 +120,13 @@ Please follow the steps below for setting up the line item script for handling t
 2. Copy the code from [here](#authentication-script) and add it to the line item script that we created in step (1). This code authenticates bundle discount requests and applies the discount only for genuine requests.
 3. Copy the Nosto bundle discount script from [here](#nosto-bundle-script) and add it to the line item script, below the authentication script (added from previous step)
 4. The authentication logic has a GET\_FROM\_NOSTO variable. Value of this variable should be replaced with Nosto secret key. **To get your secret key, please contact Nosto support**
-5. The code includes a commented testing section as shown below. This can be used to test the functionality of the bundle discount script. For testing, the script need to be unpublished in case if it's already published.
+5. Click"Save and Publish" to publish the script
+
+### Debugging Line Item Script
+
+[Nosto Bundle Script](#nosto-bundle-script) includes a commented testing section as shown below. This can be used to test the functionality of the bundle discount script. For testing, the script need to be unpublished in case if it's already published.
    * Uncomment from `Input.cart.line_times` till `end`
-   * The hash value marked with (GET\_FROM\_DEV\_CONSOLE) can be retrieved from browser's network tab
+   * The hash value marked with (GET\_FROM\_DEV\_CONSOLE) can be retrieved from browser's network tab after adding a bundle to cart
    * Replace "PROD\_1", "PROD\_2" etc., with the actual product IDs.
    * `type` can be `percent` or `dollar`
    * **Make sure to comment the lines after testing and before publishing the script again**. This is an important step. Skipping this could cause issues with applying discounts in real-time.

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -681,7 +681,7 @@ In such a case, make the following changes to the template liquid file that disp
 {% endraw %}
 ```
 
-### Issue #2: When discount is not applied
+### Issue #2: Discount is not applied
 
 ### Cause
 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -6,6 +6,14 @@
     - [Nosto Dynamic Bundle template](#nosto-dynamic-bundle-template)
     - [Shopify Line Item script](#shopify-line-item-script)
   - [Important Note](#important-note)
+  - [Scope](#scope)
+    - [Bundle Discount Example](#bundle-discount-example)
+    - [Supported Scenarios](#supported-scenarios)
+      - [When all the products of a bundle offering are added to the cart](#when-all-the-products-of-a-bundle-offering-are-added-to-the-cart)
+      - [When all the products of a bundle offering are added to the cart alogn with PDP product](#when-all-the-products-of-a-bundle-offering-are-added-to-the-cart-alogn-with-pdp-product)
+    - [Scenarios not supported](#scenarios-not-supported)
+      - [When a partial bundle is added to cart](#when-a-partial-bundle-is-added-to-cart)
+  - [Will not work If](#will-not-work-if)
   - [Known Issues](#known-issues)
   - [Authentication Script](#authentication-script)
   - [Nosto Bundle Script](#nosto-bundle-script)
@@ -129,6 +137,44 @@ Please follow the steps below for setting up the line item script for handling t
 Nosto Dynamic Bundle configuration involves two important keys, hash and secret key. Hash key is used within the bundle template and can be accessed using predefined variation `$hash`. Please avoid hard-coding this value anywhere inside the template. As dynamic bundle configurations are subjected to change, the hash key will also change accordingly. Hard-coding this key may break the functionality.
 
 Secret key, on the other hand, can be retrieved from "Dynamic Bundle Key" field in Nosto Admin Settings > Platform page. This value replaces GET\_FROM\_NOSTO placeholder in the Shopify line item script.
+
+## Scope
+Scope of this initial release is to support discounts on bundled product offerings. 
+
+### Bundle Discount Example
+Let's say, in PDP for Product#1, we display a bundle of products Product#2, Product#3 & Product#4 along with the only action button "Add to cart". 
+
+### Supported Scenarios
+The logic works only under the following scenarios:
+_Note: This section is subjected to change in future_
+
+#### When all the products of a bundle offering are added to the cart
+     
+Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above
+Upon clicking "Add to cart" button, Nosto script adds all the products of bundle Product#2, Product#3 & Product#4 to cart and applies the pre-configured discount
+
+#### When all the products of a bundle offering are added to the cart alogn with PDP product
+
+Recommendation templates for bundle offerings can be configured to include currently displayed product for discount when a bundle is added to car, using the `discountCurrentProduct` discussed under section [Nosto Dynamic Bundle template](#nosto-dynamic-bundle-template) above.
+
+Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above and assuming the `discountCurrentProduct` variable in the recommendation template is set to `true`,
+Upon clicking "Add to cart" button, Nosto script adds all the products of bundle Product#2, Product#3, Product#4 and **Product#1** (currently displayed product), to cart and applies the pre-configured discount
+
+### Scenarios not supported
+
+#### When a partial bundle is added to cart
+
+When we offer the option of selecting only specific products from a bundle, say with a checkbox or option button, in the recommendation template, specific products can be selected or deselected from a bundle and then added to cart. In this situation, the logic will not apply discount on any product.   
+Consider the example in the [Bundle Discount Example](#bundle-discount-example) section above and assuming each product in the bundle has an associated checkbox, for selecting or deselecting a product
+Product#3 in the bundle is deselected using the checkbox and "Add to cart" button is clicked. In this scenario, only Product#2 and Product#4 gets added to cart with no discounts. 
+
+**In order to overcome this issue, the template shouldn't include any option for selecting or deselecting products**
+
+## Will not work If
+
+  1. Nosto script for applying discount, provided [here](#authentication-script) and [here](#nosto-bundle-script), is not used as it is (except for replacing the SECRET_KEY)
+
+  2. SECRET_KEY is not configured correctly in [Authentication Script](#authentication-script)
 
 ## Known Issues
 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -8,10 +8,10 @@
   - [Important Note](#important-note)
   - [Nosto Bundle Script](#nosto-bundle-script)
   - [Troubleshooting](#troubleshooting)
-    - [Issue #1: When additional content displayed in cart page](#issue-1-when-additional-content-displayed-in-cart-page)
+    - [Issue #1: Additional content displayed on cart page](#issue-1-additional-content-displayed-on-cart-page)
     - [Cause](#cause)
     - [Solution](#solution)
-    - [Issue #2: When discount is not applied](#issue-2-when-discount-is-not-applied)
+    - [Issue #2: Discount is not applied](#issue-2-discount-is-not-applied)
     - [Cause](#cause-1)
     - [Solution](#solution-1)
 
@@ -19,8 +19,9 @@
 
 This documentation explains the process of setting up **Nosto - Dynamic Bundles** for automatic discount, when a bundle is added to the cart on a Shopify store. 
 
+{% hint style="info" %}
 This release of bundle discounts will work only when all products from a bundle are added to the cart. 
-{: .alert .alert-info}
+{% endhint %}
 
 ## Setup
 
@@ -81,8 +82,8 @@ Assume for example,
 
 | Product ID | Variant ID | Price |
 | :--------: | :--------: | :---: |
-|  123456789 | 4123456098 |  126$ |
-|  987654321 | 4897122347 |  100$ |
+| 123456789  | 4123456098 | 126$  |
+| 987654321  | 4897122347 | 100$  |
 
 **discount type** - percent **discount value** - 10
 
@@ -365,8 +366,9 @@ SECRET_KEY="GET_FROM_NOSTO"
 
 ## [Nosto Bundle Script](#nosto-bundle-script)
 
+{% hint style="danger" %}
 We offer support only when the script, given below, is used as-is. We don't offer support when the below script is modified, in any way. 
-{: .alert .alert-warning}
+{% endhint %}
 
 ```ruby
 # ================================ Script Code (do not edit) ================================
@@ -685,11 +687,11 @@ In such a case, make the following changes to the template liquid file that disp
 
 ### Cause
 
-1. Nosto cannot provide support for the line item script if any customisations are made to it.
-2. Incorrect value used for SECRET_KEY. 
+1. **Nosto provided line item script is customized** (_No support provided_).
+2. SECRET_KEY value is incorrect. 
 3. Issue with Bundle script configuration.
 4. Not all the products from a bundle are added to cart.
 
 ### Solution
 
-Contact Nosto support and share the line item script content for further analysis.
+Contact Nosto support and share the line item script content for further analysis. 

--- a/features/dynamic-bundle-discounts.md
+++ b/features/dynamic-bundle-discounts.md
@@ -6,15 +6,21 @@
     - [Nosto Dynamic Bundle template](#nosto-dynamic-bundle-template)
     - [Shopify Line Item script](#shopify-line-item-script)
   - [Important Note](#important-note)
-  - [Scope](#scope)
-  - [Will not work If](#will-not-work-if)
-  - [Known Issues](#known-issues)
-  - [Authentication Script](#authentication-script)
   - [Nosto Bundle Script](#nosto-bundle-script)
+  - [Troubleshooting](#troubleshooting)
+    - [Issue #1: When additional content displayed in cart page](#issue-1-when-additional-content-displayed-in-cart-page)
+    - [Cause](#cause)
+    - [Solution](#solution)
+    - [Issue #2: When discount is not applied](#issue-2-when-discount-is-not-applied)
+    - [Cause](#cause-1)
+    - [Solution](#solution-1)
 
 ## Introduction
 
-This documentation explains the process of setting up **Nosto - Dynamic Bundles** for automatic discount, when a bundle is added to the cart on a Shopify store.
+This documentation explains the process of setting up **Nosto - Dynamic Bundles** for automatic discount, when a bundle is added to the cart on a Shopify store. 
+
+This release of bundle discounts will work only when all products from a bundle are added to the cart. 
+{: .alert .alert-info}
 
 ## Setup
 
@@ -132,44 +138,7 @@ Nosto Dynamic Bundle configuration involves two important keys, hash and secret 
 
 Secret key, on the other hand, can be retrieved from "Dynamic Bundle Key" field in Nosto Admin Settings > Platform page. This value replaces GET\_FROM\_NOSTO placeholder in the Shopify line item script.
 
-## Scope
-In scope - Apply discounts when all the products in a bundle are added to cart. 
-Not in scope - Selecting only specific products from a bundle, for discounts.
 
-## Will not work If
-
-  1. Nosto script for applying discount, provided [here](#authentication-script) and [here](#nosto-bundle-script), is not used as it is (except for replacing the SECRET_KEY)
-
-  2. SECRET_KEY is not configured correctly in [Authentication Script](#authentication-script)
-
-## Known Issues
-
-Nosto implementation uses a private property field for sharing discount information with Shopify. In newer theme versions, Shopify automatically hides these fields while displaying products in cart page. In older version of themes, these fields gets exposed as shown below.
-
-![Properties Exposed](https://user-images.githubusercontent.com/82023195/168611801-666c24bc-c7f9-4edd-bdf5-2be32798391c.png)
-
-In such a case, make the following changes to the template liquid file that displays the cart information (usually cart.liquid or cart-template.liquid).
-
-```html
-{% raw %}
-{% for p in item.properties %}
-  {% assign first_character_in_key = p.first | truncate: 1, '' %} <== new line
-  {% unless p.last == blank or first_character_in_key == '_' %} <== new line
-  <small>
-    {{ p.first }}:
-
-    {% comment %}
-      Check if there was an uploaded file associated
-    {% endcomment %}
-    {% if p.last contains '/uploads/' %}
-      <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
-    {% else %}
-      {{ p.last }}
-    {% endif %}
-  </small><br />
-  {% endunless %} <== new line
-{% endfor %}
-{% endraw %}
 ```
 ## [Authentication Script](#authentication-script)
 
@@ -395,6 +364,9 @@ SECRET_KEY="GET_FROM_NOSTO"
 
 
 ## [Nosto Bundle Script](#nosto-bundle-script)
+
+We offer support only when the script, given below, is used as-is. We don't offer support when the below script is modified, in any way. 
+{: .alert .alert-warning}
 
 ```ruby
 # ================================ Script Code (do not edit) ================================
@@ -672,3 +644,52 @@ end
 
 Output.cart = Input.cart
 ```
+
+## Troubleshooting
+
+### Issue #1: When additional content displayed in cart page
+
+![Properties Exposed](https://user-images.githubusercontent.com/82023195/168611801-666c24bc-c7f9-4edd-bdf5-2be32798391c.png)
+
+### Cause
+
+Nosto implementation uses a private property field for sharing discount information with Shopify. In newer theme versions, Shopify automatically hides these fields while displaying products in cart page. In older version of themes, these fields gets exposed as shown below.
+
+### Solution
+
+In such a case, make the following changes to the template liquid file that displays the cart information (usually cart.liquid or cart-template.liquid).
+
+```html
+{% raw %}
+{% for p in item.properties %}
+  {% assign first_character_in_key = p.first | truncate: 1, '' %} <== new line
+  {% unless p.last == blank or first_character_in_key == '_' %} <== new line
+  <small>
+    {{ p.first }}:
+
+    {% comment %}
+      Check if there was an uploaded file associated
+    {% endcomment %}
+    {% if p.last contains '/uploads/' %}
+      <a href="{{ p.last }}">{{ p.last | split: '/' | last }}</a>
+    {% else %}
+      {{ p.last }}
+    {% endif %}
+  </small><br />
+  {% endunless %} <== new line
+{% endfor %}
+{% endraw %}
+```
+
+### Issue #2: When discount is not applied
+
+### Cause
+
+1. Nosto provided scripts are not used as-is. 
+2. Incorrect value used for SECRET_KEY. 
+3. Issue with Bundle script configuration.
+4. Not all the products from a bundle is added to cart.
+
+### Solution
+
+Contact Nosto support and share the line item script content for further analysis.


### PR DESCRIPTION
This PR adds a new `Scope` section in [Dynamic Bundle Discounts](https://docs.nosto.com/shopify/features/dynamic-bundle-discounts) documentation. 

## JIRA
[ADS-3608](https://nostosolutions.atlassian.net/browse/ADS-3608)