### PR TITLE
update documentation on the new 'compressUrlParameters' flag

### DIFF
--- a/implementing-nosto/implement-search/getting-started-with-nosto-search/implementing-category-pages.md
+++ b/implementing-nosto/implement-search/getting-started-with-nosto-search/implementing-category-pages.md
@@ -23,23 +23,20 @@ init({
     inputCssSelector: '#search',
     contentCssSelector: '#content', // or categoryCssSelector
     categoryComponent: categoryComponent,
-    categoryQuery: () => {
-        // extract category ID or category name from current page
-        const categryPath = document.querySelector('.category_name')
-        return {
-            name: 'serp',
-            products: {
-                categoryPath: categryPath?.textContent,
-                // or categoryId: categryPath?.textContent
-                size: 30,
-                from: 0
-            }
-        }
-    },
-    isCategoryPage: () => {
-        // Detect if category page should be rendered here
-        return location.pathname.startsWith('/collections/')
-    }
+    categoryCssSelector: '#MainContent',
+
+    // // There is a default implementation for categoryQuery, so use this custom configuration only if you need to customize it
+    // categoryQuery: () => {
+    //     return {
+    //         name: 'serp',
+    //         products: {
+    //             categoryId: "123456789",
+    //             categoryPath: 'xxx/yyy/zzz',
+    //             size: defaultConfig.serpSize,
+    //             from: 0,
+    //         }
+    //     };
+    // },
 })
 ```
 {% endcode %}

--- a/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
+++ b/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
@@ -72,13 +72,13 @@ export default () => {
 
 ### Custom search URL parameters mapping
 
-Configuration accepts optional array of URL parameter mapping functions, which allow to change behaviour of any search parameter. `customUrlMappings` accepts objects which must contain `encode` and `decode` functions.
+Manual URL Parameter Mapping (Deprecated)
+While the `customUrlMappings` array was previously used for manual configuration, it is now deprecated in favor of the `compressUrlParameters` flag. If you have specific custom mapping needs, consider updating your configuration to leverage the new flag.
 
-`encode` function receives query object which contains properties equivalent to the URL parameters, and returns object in the desired format.
+Automatic URL Parameter Compression
+The `compressUrlParameters` flag has been introduced to simplify the configuration process. When set to `true`, it automatically applies the URL parameter compression functions.
 
-Similarly, `decode` accepts mapped query object, returned from `encode` function, and it must return object in the original search format.
-
-<pre class="language-javascript"><code class="lang-javascript"><strong>import { init, compressFilterParameters, compressSortParameters } from '@nosto/preact'
+<pre class="language-javascript"><code class="lang-javascript"><strong>import { init } from '@nosto/preact'
 </strong>
 import serpComponent from './serp'
 
@@ -93,7 +93,7 @@ init({
         query: 'q',
         'products.page': 'page'
     },
-    customUrlMappings: [compressFilterParameters, compressSortParameters],
+    compressUrlParameters: true,
     serpQuery: {
         name: 'serp',
         products: {

--- a/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
+++ b/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
@@ -72,11 +72,8 @@ export default () => {
 
 ### Custom search URL parameters mapping
 
-Manual URL Parameter Mapping (Deprecated)
-While the `customUrlMappings` array was previously used for manual configuration, it is now deprecated in favor of the `compressUrlParameters` flag. If you have specific custom mapping needs, consider updating your configuration to leverage the new flag.
-
 Automatic URL Parameter Compression
-The `compressUrlParameters` flag has been introduced to simplify the configuration process. When set to `true`, it automatically applies the URL parameter compression functions.
+When the `compressUrlParameters` flag is set to `true`, it automatically applies the URL parameter compression functions for filters, sort and pagination.
 
 <pre class="language-javascript"><code class="lang-javascript"><strong>import { init } from '@nosto/preact'
 </strong>

--- a/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
+++ b/implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md
@@ -70,9 +70,8 @@ export default () => {
 ```
 {% endcode %}
 
-### Custom search URL parameters mapping
+### Automatic URL Parameter Compression
 
-Automatic URL Parameter Compression
 When the `compressUrlParameters` flag is set to `true`, it automatically applies the URL parameter compression functions for filters, sort and pagination.
 
 <pre class="language-javascript"><code class="lang-javascript"><strong>import { init } from '@nosto/preact'


### PR DESCRIPTION
Updating documentation with information on the new 'compressUrlParameters' flag for automatic URL parameter compression, deprecating the use of 'customUrlMappings' array