### PR TITLE
Document that search applies rules automatically

### DIFF
--- a/implementing-nosto/implement-search/README.md
+++ b/implementing-nosto/implement-search/README.md
@@ -35,14 +35,17 @@ For frontend integrations you can also use our JavaScript library. This library 
 |                                                | Search Templates | API       | JavaScript Library |
 | ---------------------------------------------- | ---------------- | --------- | ------------------ |
 | Can be implemented by Nosto team               | Yes              | No        | No                 |
-| Expected time to launch live                   | 1-3 weeks**\***  | 4-8 weeks | 3-6 weeks          |
+| Expected time to launch live                   | 1-3 weeks\*      | 4-8 weeks | 3-6 weeks          |
 | Headless compatible                            | Yes              | Yes       | Yes                |
 | Fully customizable frontend                    | Yes              | Yes       | Yes                |
 | Customized and managed only in Nosto dashboard | Yes              | No        | No                 |
 | Suitable for complex use cases                 | Sometimes        | Yes       | Yes                |
+| Merchandising rules applied automatically\*\*  | Yes              | Yes       | Yes                |
 
 {% hint style="info" %}
 \* This estimation is based on the merchant's team building the templates. When Nosto's frontend team builds templates via the Code Editor, this can take longer due to overall bandwidth from the team.&#x20;
+
+\*\* Matching merchandising rules are applied automatically based on requested search queries, categories, and segments, without the need to request them in API requests.
 {% endhint %}
 
 If you are looking for a fast launch without much effort we recommend going with the fully customizable pre-built templates. This type of integration does not support full API access but comes complete with an out-of-the-box search result page and autocomplete templates that can easily be customized to match most website designs and integrate even advanced custom functionality.


### PR DESCRIPTION
On more than one occasion, merchants thought they'd have to specify rules in search API requests using the `rules`  in order to use them, although they are always applied automatically. Added some documentation to clarify that across different integration types.