### PR TITLE
Clarify JS API / Session API clash

### DIFF
--- a/apis/frontend/implementation-guide-session-api/README.md
+++ b/apis/frontend/implementation-guide-session-api/README.md
@@ -4,6 +4,6 @@
 
 If you have a website, that is built atop JavaScript frameworks, such as AngularJS, Ember.js, ExtJS, Knockout.js, Meteor.js, React or Vue.js, your site has likely adopted SPA principles.
 
-**Important**: You cannot mix [JS API](../../js-apis/) and Session API. You need to use either or. If you are not sure which one to use, please contact Nosto's support.
+**Important**: You cannot mix [Tagging](../../js-apis/) and Session API. You need to use either or. If you are not sure which one to use, please contact Nosto's support.
 
 **Note:** The examples in the documentation are written in [ES5](https://www.ecma-international.org/ecma-262/5.1/) and leverage advanced browser features such as [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global\_Objects/Promise).

--- a/apis/frontend/implementation-guide-session-api/README.md
+++ b/apis/frontend/implementation-guide-session-api/README.md
@@ -4,6 +4,6 @@
 
 If you have a website, that is built atop JavaScript frameworks, such as AngularJS, Ember.js, ExtJS, Knockout.js, Meteor.js, React or Vue.js, your site has likely adopted SPA principles.
 
-**Important**: You cannot mix [Tagging](../../js-apis/) and Session API. You need to use either or. If you are not sure which one to use, please contact Nosto's support.
+**Important**: You cannot mix [Page Tagging](../../js-apis/) and Session API. You need to use either or. If you are not sure which one to use, please contact Nosto's support.
 
 **Note:** The examples in the documentation are written in [ES5](https://www.ecma-international.org/ecma-262/5.1/) and leverage advanced browser features such as [Promises](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global\_Objects/Promise).

--- a/apis/js-apis/README.md
+++ b/apis/js-apis/README.md
@@ -4,7 +4,7 @@ In most implementations, there isn't any need to use the Nosto JavaScript API an
 
 Typically calling the API should be approached only after the normal tagging implementation has been done and now needs to be extended with something that doesn’t come out of the box. The JavaScript API is commonly used to support dynamic functionality i.e. without a page reload. For example, showing recommendations in a product quick view.
 
-If you are working on a Single-Page App \(SPA\) or a Progressive Web Application \(PWA\) you most likely want to use [Session API](../frontend/implementation-guide-session-api/). Also, please note that you can not use both, Session API and Tagging on a same page or application.
+If you are working on a Single-Page App \(SPA\) or a Progressive Web Application \(PWA\) you most likely want to use [Session API](../frontend/implementation-guide-session-api/). Also, please note that you cannot use both, Session API and Page Tagging on a same page or application.
 
 ## Prerequisites
 

--- a/apis/js-apis/README.md
+++ b/apis/js-apis/README.md
@@ -4,7 +4,7 @@ In most implementations, there isn't any need to use the Nosto JavaScript API an
 
 Typically calling the API should be approached only after the normal tagging implementation has been done and now needs to be extended with something that doesn’t come out of the box. The JavaScript API is commonly used to support dynamic functionality i.e. without a page reload. For example, showing recommendations in a product quick view.
 
-If you are working on a Single-Page App \(SPA\) or a Progressive Web Application \(PWA\) you most likely want to use [Session API](../frontend/implementation-guide-session-api/). Also, please note that you can not use both, Session API and JS API on a same page or application.
+If you are working on a Single-Page App \(SPA\) or a Progressive Web Application \(PWA\) you most likely want to use [Session API](../frontend/implementation-guide-session-api/). Also, please note that you can not use both, Session API and Tagging on a same page or application.
 
 ## Prerequisites
 

--- a/implementing-nosto/implement-on-your-website/README.md
+++ b/implementing-nosto/implement-on-your-website/README.md
@@ -27,4 +27,4 @@ If you have implemented SPA / PWA on top a platform that Nosto has extension for
 
 ## When dynamic functionality is needed / no page reload
 
-In case your website implement some dynamic functionality, you can use the [JS API](../../apis/js-apis/). Note that you can not mix Session API and JS API.
+In case your website implement some dynamic functionality, you can use the [JS API](../../apis/js-apis/). Note that you cannot mix Session API and Page Tagging.


### PR DESCRIPTION
Replace JS API with Tagging in warning sections that the Session API should not be mixed with the JS API.
Since the JS API covers everything it is better to document the conflict as Tagging vs Session API