### PR TITLE
Document specific autocomplete type requirements

### DIFF
--- a/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
+++ b/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
@@ -7,7 +7,7 @@ Autocomplete provides keyword suggestions to assist users in completing their qu
 Check out [autocomplete's look & feel guidelines](https://help.nosto.com/en/articles/7169076-autocomplete-s-look-feel-guidelines).
 
 {% hint style="info" %}
-When integrating Autocomplete you have the option to directly access the API, or you can use our existing [Autocomplete JavaScript library](../search/implement-autocomplete-using-library/) that provides most of the required functionality out of the box.
+When integrating autocomplete you have the option to directly access the API, or you can use our existing [Autocomplete JavaScript library](../search/implement-autocomplete-using-library/) that provides most of the required functionality out of the box.
 {% endhint %}
 
 ## Requirements

--- a/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
+++ b/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
@@ -10,6 +10,17 @@ Check out [autocomplete's look & feel guidelines](https://help.nosto.com/en/arti
 When integrating Autocomplete you have the option to directly access the API, or you can use our existing [Autocomplete JavaScript library](../search/implement-autocomplete-using-library/) that provides most of the required functionality out of the box.
 {% endhint %}
 
+## Requirements
+
+Some autocomplete features are available conditionally.
+
+* **Keyword suggestions** require searchable fields to be marked for autocomplete.
+* **Popular searches** require a function Nosto tracking integration for searches.
+* **Category suggestions** depend on available categories (including URLs)
+  being [sent to Nosto](../../../apis/graphql-an-introduction/graphql-using-mutations/updating-categories).
+  * The Shopify integration sends categories to Nosto out-of-the-box, with no extra work required.
+  * The Shopware 6 plugin automatically sends categories to Nosto without requiring extra work from version 5.1.4.
+
 ## API Requests <a href="#autocomplete" id="autocomplete"></a>
 
 ### Example

--- a/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
+++ b/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
@@ -17,7 +17,7 @@ Some autocomplete features are available conditionally.
 * **Keyword suggestions** require searchable fields to be marked for autocomplete.
 * **Popular searches** require a function Nosto tracking integration for searches.
 * **Category suggestions** depend on available categories (including URLs)
-  being [sent to Nosto](../../../apis/graphql-an-introduction/graphql-using-mutations/updating-categories).
+  being [sent to Nosto](../../../apis/graphql-an-introduction/graphql-using-mutations/updating-categories.md).
   * The Shopify integration sends categories to Nosto out-of-the-box, with no extra work required.
   * The Shopware 6 plugin automatically sends categories to Nosto without requiring extra work from version 5.1.4.
 

--- a/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
+++ b/implementing-nosto/implement-search/implement-search-using-api/implementing-autocomplete.md
@@ -16,10 +16,11 @@ Some autocomplete features are available conditionally.
 
 * **Keyword suggestions** require searchable fields to be marked for autocomplete.
 * **Popular searches** require a function Nosto tracking integration for searches.
-* **Category suggestions** depend on available categories (including URLs)
-  being [sent to Nosto](../../../apis/graphql-an-introduction/graphql-using-mutations/updating-categories.md).
+* **Category suggestions** depend on available categories (including URLs) being sent to Nosto.
   * The Shopify integration sends categories to Nosto out-of-the-box, with no extra work required.
   * The Shopware 6 plugin automatically sends categories to Nosto without requiring extra work from version 5.1.4.
+  * For other platforms and custom integrations, send categories to Nosto via
+    [GraphQL API](../../../apis/graphql-an-introduction/graphql-using-mutations/updating-categories.md).
 
 ## API Requests <a href="#autocomplete" id="autocomplete"></a>
 


### PR DESCRIPTION
Make it clear that category suggestions require category information to be sent to Nosto.