### PR TITLE
Search: Fix link to Code Editor implementations passing the variation ID

### DIFF
--- a/.gitbook/includes/search-variation-implementation.md
+++ b/.gitbook/includes/search-variation-implementation.md
@@ -6,4 +6,4 @@ The search/category merchandising (universal) API supports specifying the variat
 
 If specified, the selected variation's specific properties automatically replace the corresponding values in the top-level product. All features (e.g., merchandising rules, facets, filters, sorting) work with the selected variation's values automatically when the variation ID is provided.
 
-For Nosto code editor integrations, please refer to a [simplified version of this process](../../implement-search/implement-search-using-code-editor/implementing-search-page/#multi-currency).
+For Nosto code editor integrations, please refer to a [simplified version of this process](../../implementing-nosto/implement-search/implement-search-using-code-editor/implementing-search-page.md#multi-currency).


### PR DESCRIPTION
* Link was: https://github.com/Nosto/wiki-docs/blob/Techdocs/implement-search/implement-search-using-code-editor/implementing-search-page/README.md#multi-currency
* `implementing-nosto/` was missing
* file names need `.md`, otherwise Gitbook links to README.md within the path

Please review the link for "[simplified version of this process]" here:
* https://docs.nosto.com/techdocs/~/revisions/pPsVnJQEjRQ7xlJwnAYO/implementing-nosto/implement-on-your-website/advanced-implementation/adding-support-for-customer-group-pricing#integration-with-search-category-merchandising-universal
* https://docs.nosto.com/techdocs/~/revisions/pPsVnJQEjRQ7xlJwnAYO/implementing-nosto/implement-on-your-website/advanced-implementation/adding-support-for-multi-currency#integration-with-search-category-merchandising-universal