### PR TITLE
Chore: Document searchType tracking

### DIFF
--- a/implementing-nosto/implement-search/features/hybrid-vector-search.md
+++ b/implementing-nosto/implement-search/features/hybrid-vector-search.md
@@ -31,6 +31,33 @@ This information can be optionally used in the search result page to convey whet
 Hybrid Vector Search results can be more general than keyword search results —
 communicating with the user helps with setting expectations.
 
+### Tracking requirements
+
+In order to benefit from analytics for Hybrid Vector Search, the search type must be included in impression- and click tracking events sent to Nosto.
+
+The `searchType` value queried from the search API can be included in tracking events verbatim within the tracking metadata property `searchType`, on the same level as `query`.
+Here is an example for a well-formed tracking metadata that includes the search type:
+
+```json
+{
+  "hasResults": true,
+  "autoComplete": false,
+  "autoCorrect": false,
+  "keyword": false,
+  "organic": true,
+  "refined": false,
+  "refinedQuery": null,
+  "sorted": false,
+  "query":  "t-shirt",
+  "resultId": "d65b040c-56ae-4c6d-a038-fe908e140855",
+  "searchType": "vector" // or "keyword"
+}
+```
+
+When using NostoJS' automatic tracking tracking (using the `track` parameter), `searchType` tracking is included automatically, and no adjustments to the integration are required.
+
+API integrations and integrations managing tracking metadata manually need to take care of passing through `searchType` explicitly.
+
 ## Limitations
 
 When Hybrid Vector Search engages, features of Nosto search work as normal with one major caveat:

--- a/implementing-nosto/implement-search/implement-search-using-api/analytics-ab-testing.md
+++ b/implementing-nosto/implement-search/implement-search-using-api/analytics-ab-testing.md
@@ -63,6 +63,7 @@ query {
     products {
       total
       fuzzy
+      searchType
       hits {
         productId
       }
@@ -187,7 +188,8 @@ Here is an example of what metadata looks like for search requests:
   "refinedQuery": null,
   "sorted": false,
   "query":  "t-shirt",
-  "resultId": "d65b040c-56ae-4c6d-a038-fe908e140855"
+  "resultId": "d65b040c-56ae-4c6d-a038-fe908e140855",
+  "searchType": "keyword"
 }
 ```
 
@@ -203,6 +205,7 @@ Properties:
 * `sorted`: `true` when sorting by anything other than `_score`. Sorting by `_score` is default behavior if no sort parameter is supplied in the search request.
 * `query`: The current search query entered by the user into the search field.
 * `resultId`: Unique ID for this interaction. UUID4 is particularly useful for this.
+* `searchType`: Type of search logic being used, as returned by the API's `searchType` field. This is required for merchants using Hybrid Vector Search, but otherwise optional.
 
 #### Category tracking metadata
 
@@ -525,6 +528,7 @@ function transformSearchResultsToTrackingMetadata(query, searchResults, isAutoCo
     query,
     refinedQuery: store.mostRecentSearchMetadata?.query ?? null,
     resultId: crypto.randomUUID(),
+    searchType: searchResults.search.products.searchType
   }
 }
 
@@ -551,6 +555,7 @@ async function search(query, isAutoComplete = false, isOrganic = true) {
         products {
           total
           fuzzy
+          searchType
           hits {
             productId
             name


### PR DESCRIPTION
Depending on integration type, using Hybrid Vector Search can require adjustments to the tracking implementation. Describe these and update the API integration docs to include `searchType` tracking as well.